### PR TITLE
Add link to maintenance calendar

### DIFF
--- a/views/homepage.ejs
+++ b/views/homepage.ejs
@@ -21,6 +21,7 @@
 
    <!-- Status list -->		
    <div id="statusio_components" class="page_section">
+      <p>See the <strong><a href="//www.cyverse.org/learning-center/maintenance-calendar">Maintenance Calendar</a></strong>&nbsp;for scheduled maintenances of CyVerse systems.</p>
 
       <% Results.forEach(function(group) { %>
 


### PR DESCRIPTION
Per the request of Mary Margaret, I'm adding a link to the maintenance calendar on status.io.


![screen shot 2017-01-26 at 11 26 28 am](https://cloud.githubusercontent.com/assets/3847314/22344705/5f323a12-e3ba-11e6-8ee9-8664c48b7ccf.png)
